### PR TITLE
Allowing server to accept baseDir 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Called with the `__coverage__` from the browser, can be used with code coverage 
 ##### port
 Sets the port for the server
 
+##### static
+Sets the base directory for serving static files. See [here](https://expressjs.com/en/guide/using-middleware.html#middleware.built-in). This is especially helpful for [loading fixtures] (https://github.com/jasmine/gulp-jasmine-browser/issues/9).    
 ##### random
 If true, the headless server runs the tests in random order
 

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -33,6 +33,7 @@ const Server = {
 
     app.use(favicon(path.resolve(__dirname, '..', 'public', 'jasmine_favicon.png')));
 
+    app.use(express.static(options.static.root,options.static.options));
     app.get('/', function(req, res) {
       const {whenReady = () => Promise.resolve()} = options;
       renderFile(res, files, 'specRunner.html', whenReady);


### PR DESCRIPTION
This will allow server to accept parameters for express.static(....) . Should make  [loading fixtures](https://github.com/jasmine/gulp-jasmine-browser/issues/9) easier.