### PR TITLE
Restore exiting behaviour on SIGINT and SIGTERM

### DIFF
--- a/src/lib/headless.js
+++ b/src/lib/headless.js
@@ -84,7 +84,10 @@ function createServer(options) {
       withSandbox && (env.WITH_SANDBOX = true);
       const phantomProcess = spawn(command, compact([runner, port, query]), {cwd: resolve(__dirname, './runners'), env, stdio});
       phantomProcess.on('close', () => server.close());
-      ['SIGINT', 'SIGTERM'].forEach(e => process.once(e, () => phantomProcess && phantomProcess.kill()));
+      ['SIGINT', 'SIGTERM'].forEach(e => process.once(e, () => {
+        phantomProcess && phantomProcess.kill();
+        process.exit();
+      }));
       next(null, phantomProcess[output].pipe(split(parse)));
     }),
     toReporter(reporter || defaultReporters(opts, profile), {onError, onConsoleMessage, onCoverage, onSnapshot}),


### PR DESCRIPTION
I have a watch task in gulp, like this (simplified):

```js
const testModules = browserify({
    entries: glob.sync(`src/**/*-test.js`),
    cache: {},
    packageCache: {},
});

function unittest() {
    return testModules.bundle()
        .pipe(vinylStream('tests.js'))
        .pipe(vinylBuffer())
        .pipe(plugins.jasmineBrowser.specRunner({console: true}))
        .pipe(plugins.jasmineBrowser.headless({driver: 'phantomjs'});
}

gulp.task('watch', function() {
    testModules.plugin('watchify');
    testModules.on('update', unittest);
    unittest();
});
```

and I run it using `yarn gulp watch` and it works wonderfully well. However, when I terminate the task by hitting ctrl-c in my terminal, the gulp process doesn't actually stop. I noticed this after stopping and restarting the task several times; when changing some source code, the tests would run multiple times. The number of duplicates increases with every stop-start cycle. `ps aux | grep gulp` confirms that these processes acccumulate.

After digging a bit, I found [this](https://nodejs.org/api/process.html#process_signal_events) piece of Node.js documentation (second item in the bullet list):

> 'SIGTERM' and 'SIGINT' have default handlers on non-Windows platforms that reset the terminal mode before exiting with code 128 + signal number. If one of these signals has a listener installed, its default behavior will be removed (Node.js will no longer exit).

And indeed, it turned out that gulp-jasmine-browser is listening to these events. This pull request resolves the issue by manually calling `process.exit()` within the event handlers.