### PR TITLE
Changes to avoid config deprecation warnings (from jasmine-core)

### DIFF
--- a/src/lib/boot.js
+++ b/src/lib/boot.js
@@ -6,31 +6,31 @@
       getWindowLocation: function() { return window.location; }
     });
 
-    configOptions = {};
+    var configuration = {};
 
     var stoppingOnSpecFailure = queryString.getParam('failFast');
-    configOptions.failFast = typeof stoppingOnSpecFailure === 'undefined' ? true : stoppingOnSpecFailure;
+    configuration.failFast = typeof stoppingOnSpecFailure === 'undefined' ? true : stoppingOnSpecFailure;
 
     var throwingExpectationFailures = queryString.getParam('throwFailures');
-    configOptions.oneFailurePerSpec = throwingExpectationFailures;
+    configuration.oneFailurePerSpec = throwingExpectationFailures;
 
     var random = queryString.getParam('random');
-    configOptions.random = random;
+    configuration.random = random;
 
     var seed = queryString.getParam('seed');
     if (seed) {
-      env.seed(seed);
+      configuration.seed = seed;
     }
 
     var specFilter = new SpecFilter({
       filterString: function() { return queryString.getParam('spec'); }
     });
 
-    configOptions.specFilter = function(spec) {
+    configuration.specFilter = function(spec) {
       return specFilter.matches(spec.getFullName());
     };
 
-    env.configure(configOptions);
+    env.configure(configuration);
   }
 
   function extend(destination, source) {

--- a/src/lib/boot.js
+++ b/src/lib/boot.js
@@ -6,14 +6,16 @@
       getWindowLocation: function() { return window.location; }
     });
 
+    configOptions = {};
+
     var stoppingOnSpecFailure = queryString.getParam('failFast');
-    env.stopOnSpecFailure(typeof stoppingOnSpecFailure === 'undefined' ? true : stoppingOnSpecFailure);
+    configOptions.failFast = typeof stoppingOnSpecFailure === 'undefined' ? true : stoppingOnSpecFailure;
 
     var throwingExpectationFailures = queryString.getParam('throwFailures');
-    env.throwOnExpectationFailure(throwingExpectationFailures);
+    configOptions.oneFailurePerSpec = throwingExpectationFailures;
 
     var random = queryString.getParam('random');
-    env.randomizeTests(random);
+    configOptions.random = random;
 
     var seed = queryString.getParam('seed');
     if (seed) {
@@ -24,9 +26,11 @@
       filterString: function() { return queryString.getParam('spec'); }
     });
 
-    env.specFilter = function(spec) {
+    configOptions.specFilter = function(spec) {
       return specFilter.matches(spec.getFullName());
     };
+
+    env.configure(configOptions);
   }
 
   function extend(destination, source) {


### PR DESCRIPTION
Change the way that certain configuration options are set to Jasmine's environment to be compliant with jasmine-core and avoid deprecation warnings.